### PR TITLE
hotfix: Normalize usernames to lowercase in memory for case-insensiti…

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
@@ -125,7 +125,7 @@ class DatabaseStorage : AccountStorage {
         InventoriesTable.deleteWhere { playerId inList playerIds.values }
         val invData = accounts.flatMap { save -> save.inventories.toList().map { Triple(save.name, it.first, it.second) } }
         InventoriesTable.batchUpsert(invData, InventoriesTable.playerId, InventoriesTable.inventoryName) { (id, inventory, items) ->
-            this[InventoriesTable.playerId] = playerIds.getValue(id)
+            this[InventoriesTable.playerId] = playerIds.getValue(id.lowercase())
             this[InventoriesTable.inventoryName] = inventory
             this[InventoriesTable.items] = items.map { it.id }
             this[InventoriesTable.amounts] = items.map { it.value }
@@ -137,7 +137,7 @@ class DatabaseStorage : AccountStorage {
         VariablesTable.deleteWhere { playerId inList playerIds.values }
         val varData = accounts.flatMap { save -> save.variables.toList().map { Triple(save.name, it.first, it.second) } }
         VariablesTable.batchUpsert(varData, VariablesTable.playerId, VariablesTable.name) { (id, name, value) ->
-            this[VariablesTable.playerId] = playerIds.getValue(id)
+            this[VariablesTable.playerId] = playerIds.getValue(id.lowercase())
             this[VariablesTable.name] = name
             when (value) {
                 is String -> {
@@ -176,7 +176,7 @@ class DatabaseStorage : AccountStorage {
 
     private fun saveLevels(accounts: List<PlayerSave>, playerIds: Map<String, Int>) {
         LevelsTable.batchUpsert(accounts, LevelsTable.playerId) { playerSave ->
-            this[LevelsTable.playerId] = playerIds.getValue(playerSave.name)
+            this[LevelsTable.playerId] = playerIds.getValue(playerSave.name.lowercase())
             val levels = playerSave.levels
             this[LevelsTable.attack] = levels[0]
             this[LevelsTable.defence] = levels[1]
@@ -208,7 +208,7 @@ class DatabaseStorage : AccountStorage {
 
     private fun saveExperience(accounts: List<PlayerSave>, playerIds: Map<String, Int>) {
         ExperienceTable.batchUpsert(accounts, ExperienceTable.playerId) { playerSave ->
-            this[ExperienceTable.playerId] = playerIds.getValue(playerSave.name)
+            this[ExperienceTable.playerId] = playerIds.getValue(playerSave.name.lowercase())
             val experience = playerSave.experience
             this[ExperienceTable.attack] = experience[0]
             this[ExperienceTable.defence] = experience[1]


### PR DESCRIPTION
This PR addresses issues with username casing inconsistencies between the application and PostgreSQL, particularly on Linux filesystems.

Changes:
- Lowercase keys in playerIds map.
- Apply `.lowercase()` during all map lookups in saveExperience, saveLevels, saveVariables, and saveInventories.
- Ensures compatibility with case-sensitive environments.

No changes were made to how names are stored in the database, preserving original casing.
