### PR TITLE
feat: Replace dynamicXPMod setting with flexible experienceRateMin/Max

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/exp/Experience.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/exp/Experience.kt
@@ -33,22 +33,21 @@ class Experience(
     }
 
     fun add(skill: Skill, baseExperience: Double) {
-        if (baseExperience <= 0.0) {
-            return
+        if (baseExperience <= 0.0) return
+
+        val rateMin = Settings["world.experienceRateMin", 1.0]
+        val rateMax = Settings["world.experienceRateMax", 1.0]
+
+        val playerLevel = level(skill, get(skill)).toDouble()
+        val maxLevel = Level.MAX_LEVEL.toDouble()
+
+        val modifier = if (rateMin != rateMax) {
+            interpolate(rateMin, rateMax, playerLevel / maxLevel)
+        } else {
+            rateMin
         }
 
-        val xpModSetting = Settings["world.dynamicXPMod", "off"].lowercase()
-        val playerMaxLevel = level(skill, get(skill))
-        val maxLevel = Level.MAX_LEVEL
-
-        val modifier = when (xpModSetting) {
-            "linear" -> interpolate(1.0, 5.0, playerMaxLevel.toDouble() / maxLevel)
-            "inverse" -> interpolate(5.0, 1.0, playerMaxLevel.toDouble() / maxLevel)
-            else -> 1.0
-        }
-
-        val experienceRate = Settings["world.experienceRate", DEFAULT_EXPERIENCE_RATE]
-        val adjustedExperience = baseExperience * modifier * experienceRate
+        val adjustedExperience = baseExperience * modifier
 
         if (blocked.contains(skill)) {
             events.emit(BlockedExperience(skill, adjustedExperience))

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/level/Interpolation.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/level/Interpolation.kt
@@ -12,7 +12,8 @@ object Interpolation {
     }
 
     fun interpolate(start: Double, end: Double, fraction: Double): Double {
-        return start + fraction * (end - start)
+        val result = start + fraction * (end - start)
+        return kotlin.math.round(result * 10) / 10.0
     }
 
     fun lerp(value: Int, inRange: IntRange, result: IntRange): Int {

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -68,7 +68,11 @@ world.home.y=3219
 world.messages=false
 
 # Experience multiplier (1.0 = normal XP rate)
-world.experienceRate=1.0
+# Set both to the same value (e.g., 1.0) for static XP
+# Set min < max for increasing XP at higher levels
+# Set min > max for decreasing XP at higher levels
+world.experienceRateMin=1.0
+world.experienceRateMax=1.0
 
 # world.dynamicXPMod - Linear (1x-5x multiplier) or inverse (5x-1x multiplier) XP scaling: "off", "linear", or "inverse"
 world.dynamicXPMod=off


### PR DESCRIPTION
feat: Replace dynamicXPMod setting with flexible experienceRateMin/Max

Removes the old `world.dynamicXPMod` option ("off", "linear", "inverse") in favor of a cleaner approach using `world.experienceRateMin` and `world.experienceRateMax`. This enables admins to:

- Set a fixed XP multiplier (by using equal min/max)
- Use level-based interpolation with increasing XP rates (min < max)
- Use level-based interpolation with decreasing XP rates (min > max)

This simplifies config while making the system more flexible.
